### PR TITLE
Version 2 of MRTFetchedResultsController

### DIFF
--- a/MRTFetchedResultsController.xcodeproj/project.pbxproj
+++ b/MRTFetchedResultsController.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0CA948151FD581D200728A40 /* NSSet+Combinatorics.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA948131FD581D200728A40 /* NSSet+Combinatorics.m */; };
 		0CBB3BCC1F0651150053B8B9 /* MRTTestMoveHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB3BCB1F0651150053B8B9 /* MRTTestMoveHelper.m */; };
 		0CBB3BCF1F0674A70053B8B9 /* NSArray+Permutation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB3BCE1F0674A70053B8B9 /* NSArray+Permutation.m */; };
+		9F88AEB72407DC3D00C90A28 /* MRTFetchedResultsControllerCallbackOrderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F88AEB62407DC3C00C90A28 /* MRTFetchedResultsControllerCallbackOrderTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		0CBB3BCB1F0651150053B8B9 /* MRTTestMoveHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MRTTestMoveHelper.m; sourceTree = "<group>"; };
 		0CBB3BCD1F0674A70053B8B9 /* NSArray+Permutation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Permutation.h"; sourceTree = "<group>"; };
 		0CBB3BCE1F0674A70053B8B9 /* NSArray+Permutation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Permutation.m"; sourceTree = "<group>"; };
+		9F88AEB62407DC3C00C90A28 /* MRTFetchedResultsControllerCallbackOrderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MRTFetchedResultsControllerCallbackOrderTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 			children = (
 				0C351CF61B049829002AE121 /* MRTFetchedResultsControllerTests.m */,
 				0C4980C81DA6561F00DB986D /* MRTFetchedResultsControllerProgressiveChangesTests.m */,
+				9F88AEB62407DC3C00C90A28 /* MRTFetchedResultsControllerCallbackOrderTests.m */,
 				0CBB3BCA1F0651150053B8B9 /* MRTTestMoveHelper.h */,
 				0CBB3BCB1F0651150053B8B9 /* MRTTestMoveHelper.m */,
 				0CBB3BCD1F0674A70053B8B9 /* NSArray+Permutation.h */,
@@ -150,6 +153,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 0C351CE31B0494B8002AE121;
@@ -179,6 +183,7 @@
 			files = (
 				0C4980C91DA6561F00DB986D /* MRTFetchedResultsControllerProgressiveChangesTests.m in Sources */,
 				0C351D481B04E4E8002AE121 /* Note.m in Sources */,
+				9F88AEB72407DC3D00C90A28 /* MRTFetchedResultsControllerCallbackOrderTests.m in Sources */,
 				0C351CFB1B04982F002AE121 /* MRTFetchedResultsController.m in Sources */,
 				0CBB3BCF1F0674A70053B8B9 /* NSArray+Permutation.m in Sources */,
 				0C351CF71B049829002AE121 /* MRTFetchedResultsControllerTests.m in Sources */,

--- a/MRTFetchedResultsControllerTests/MRTFetchedResultsControllerCallbackOrderTests.m
+++ b/MRTFetchedResultsControllerTests/MRTFetchedResultsControllerCallbackOrderTests.m
@@ -1,0 +1,277 @@
+//
+//  MRTFetchedResultsControllerCallbackOrderTests.m
+//  MRTFetchedResultsControllerTests
+//
+//  Created by Konstantin Victorovich Erokhin on 27/02/2020.
+//
+
+#import <XCTest/XCTest.h>
+#import <CoreData/CoreData.h>
+
+#import "Note.h"
+#import "MRTFetchedResultsController.h"
+
+
+@interface MRTFetchedResultsControllerCallbackOrderBaseTests : XCTestCase <MRTFetchedResultsControllerDelegate>
+
+@property (strong) NSManagedObjectContext *managedObjectContext;
+@property (strong) NSManagedObjectContext *privateManagedObjectContext;
+
+@property (nonatomic) NSUInteger numberOfCallsWillBeginChanging;
+@property (nonatomic) NSUInteger numberOfCallsDidChangeWithChanges;
+@property (nonatomic) NSUInteger numberOfCallsDidChangeWithProgressiveChanges;
+@property (nonatomic) NSUInteger numberOfCallsDidEndChanging;
+@property (nonatomic) NSUInteger numberOfCallsDidEndChangingWithChanges;
+@property (nonatomic) NSUInteger numberOfCallsDidEndChangingWithProgressiveChanges;
+
+@property (strong) NSMutableArray *targetArray;
+
+@property (nonatomic, strong) XCTestExpectation * expectation;
+@property (nonatomic) CGFloat expectationsDefaultTimeout;
+
+- (void)testAnyOperationWithExpectationHandler:(XCWaitCompletionHandler)expectationHandler;
+
+@end
+
+@implementation MRTFetchedResultsControllerCallbackOrderBaseTests
+
+
+- (void)setUp
+{
+    [super setUp];
+
+    [self setupCoreData];
+    
+    self.targetArray = [NSMutableArray array];
+    
+    self.expectationsDefaultTimeout = 0.1;
+    
+    // will callbacks
+    self.numberOfCallsWillBeginChanging = 0;
+    // change callbacks
+    self.numberOfCallsDidChangeWithChanges = 0;
+    self.numberOfCallsDidChangeWithProgressiveChanges = 0;
+    // did callbacks
+    self.numberOfCallsDidEndChanging = 0;
+    self.numberOfCallsDidEndChangingWithChanges = 0;
+    self.numberOfCallsDidEndChangingWithProgressiveChanges = 0;
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void) setupCoreData
+{
+    // Core Data Stack
+    NSURL *modelURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"Model" withExtension:@"momd"];
+    NSManagedObjectModel *mom = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+    
+    NSError *error;
+    NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:mom];
+    [coordinator addPersistentStoreWithType:NSInMemoryStoreType configuration:nil URL:nil options:nil error:&error];
+    
+    self.managedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    self.managedObjectContext.persistentStoreCoordinator = coordinator;
+}
+
+- (void)testAnyOperationWithExpectationHandler:(XCWaitCompletionHandler)expectationHandler
+{
+    // Creating the fetchedResultsController
+    MRTFetchedResultsController *fetchedResultsController = [self notesFetchedResultsController];
+    [fetchedResultsController performFetch:nil];
+    
+    // Inserting a new object inside the managedObjectContext (could be any operation for this test)
+    [NSEntityDescription insertNewObjectForEntityForName:@"Note" inManagedObjectContext:self.managedObjectContext];
+    
+    // Creating a new expectation
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Insertion of new object notified"];
+    expectation.expectedFulfillmentCount = 1;
+    self.expectation = expectation;
+    
+    // Waiting for all expectations
+    [self waitForExpectationsWithTimeout:self.expectationsDefaultTimeout handler:expectationHandler];
+}
+
+// MRTFetchedResultsController utils
+
+- (MRTFetchedResultsController *)notesFetchedResultsController
+{
+    // Creating the fetch request
+    NSFetchRequest *request = [[NSFetchRequest alloc] init];
+    request.entity = [NSEntityDescription entityForName:@"Note" inManagedObjectContext:self.managedObjectContext];
+    request.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"order" ascending:YES]];
+    
+    // Creating the fetchedResultsController
+    MRTFetchedResultsController *fetchedResultsController = [[MRTFetchedResultsController alloc] initWithManagedObjectContext:self.managedObjectContext fetchRequest:request];
+    fetchedResultsController.delegate = self;
+    
+    return fetchedResultsController;
+}
+
+@end
+
+#pragma mark - Zero Attributes Callback
+
+@interface MRTFetchedResultsControllerCallbackOrderZeroAttributesCallbacksTests : MRTFetchedResultsControllerCallbackOrderBaseTests
+
+@end
+
+@implementation MRTFetchedResultsControllerCallbackOrderZeroAttributesCallbacksTests
+
+- (void)testWillBeginChangingAndDidChangeWithChangesAndDidEndChangingBeingCalled
+{
+    [self testAnyOperationWithExpectationHandler:^(NSError *error) {
+        if(error) XCTFail(@"Expectation Failed with error: %@", error);
+        // Checking the number of callbacks
+        XCTAssertEqual(self.numberOfCallsWillBeginChanging, 1, @"Number of will callbacks is wrong");
+        XCTAssertEqual(self.numberOfCallsDidChangeWithChanges, 1, @"Number of didChange callbacks with only changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidChangeWithProgressiveChanges, 0, @"Number of didChange callbacks with with progressive changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChanging, 1, @"Number of didEndChanging callbacks is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChangingWithChanges, 0, @"Number of didEndChanging callbacks with only changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChangingWithProgressiveChanges, 0, @"Number of didEndChanging callbacks with progressive changes is wrong");
+    }];
+}
+
+// MRTFetchedResultsControllerDelegate
+
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
+{
+    self.numberOfCallsWillBeginChanging++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+{
+    [self.expectation fulfill];
+    self.numberOfCallsDidChangeWithChanges++;
+}
+
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
+{
+    self.numberOfCallsDidEndChanging++;
+}
+
+@end
+
+#pragma mark - One Attribute Callback
+
+@interface MRTFetchedResultsControllerCallbackOrderOneAttributesCallbacksTests : MRTFetchedResultsControllerCallbackOrderBaseTests
+
+@end
+
+@implementation MRTFetchedResultsControllerCallbackOrderOneAttributesCallbacksTests
+
+- (void)testWillBeginChangingAndDidChangeWithProgressiveChangesAndDidEndChangingWithChangesBeingCalled
+{
+    [self testAnyOperationWithExpectationHandler:^(NSError *error) {
+        if(error) XCTFail(@"Expectation Failed with error: %@", error);
+        // Checking the number of callbacks
+        XCTAssertEqual(self.numberOfCallsWillBeginChanging, 1, @"Number of will callbacks is wrong");
+        XCTAssertEqual(self.numberOfCallsDidChangeWithChanges, 0, @"Number of didChange callbacks with only changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidChangeWithProgressiveChanges, 1, @"Number of didChange callbacks with with progressive changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChanging, 0, @"Number of didEndChanging callbacks is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChangingWithChanges, 1, @"Number of didEndChanging callbacks with only changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChangingWithProgressiveChanges, 0, @"Number of didEndChanging callbacks with progressive changes is wrong");
+    }];
+}
+
+// MRTFetchedResultsControllerDelegate
+
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
+{
+    self.numberOfCallsWillBeginChanging++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+{
+    [self.expectation fulfill];
+    self.numberOfCallsDidChangeWithChanges++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+               progressiveChange:(MRTFetchedResultsControllerChange *)progressiveChange
+{
+    [self.expectation fulfill];
+    self.numberOfCallsDidChangeWithProgressiveChanges++;
+}
+
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
+{
+    self.numberOfCallsDidEndChanging++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                  didEndChanging:(NSArray<MRTFetchedResultsControllerChange *> *)changes
+{
+    self.numberOfCallsDidEndChangingWithChanges++;
+}
+
+@end
+
+#pragma mark - Two Attribute Callback
+
+@interface MRTFetchedResultsControllerCallbackOrderTwoAttributesCallbacksTests : MRTFetchedResultsControllerCallbackOrderBaseTests
+
+@end
+
+@implementation MRTFetchedResultsControllerCallbackOrderTwoAttributesCallbacksTests
+
+- (void)testWillBeginChangingAndDidChangeWithProgressiveChangesAndDidEndChangingWithProgressiveChangesBeingCalled
+{
+    [self testAnyOperationWithExpectationHandler:^(NSError *error) {
+        if(error) XCTFail(@"Expectation Failed with error: %@", error);
+        // Checking the number of callbacks
+        XCTAssertEqual(self.numberOfCallsWillBeginChanging, 1, @"Number of will callbacks is wrong");
+        XCTAssertEqual(self.numberOfCallsDidChangeWithChanges, 0, @"Number of didChange callbacks with only changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidChangeWithProgressiveChanges, 1, @"Number of didChange callbacks with with progressive changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChanging, 0, @"Number of didEndChanging callbacks is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChangingWithChanges, 0, @"Number of didEndChanging callbacks with only changes is wrong");
+        XCTAssertEqual(self.numberOfCallsDidEndChangingWithProgressiveChanges, 1, @"Number of didEndChanging callbacks with progressive changes is wrong");
+    }];
+}
+
+// MRTFetchedResultsControllerDelegate
+
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
+{
+    self.numberOfCallsWillBeginChanging++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+{
+    [self.expectation fulfill];
+    self.numberOfCallsDidChangeWithChanges++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+               progressiveChange:(MRTFetchedResultsControllerChange *)progressiveChange
+{
+    [self.expectation fulfill];
+    self.numberOfCallsDidChangeWithProgressiveChanges++;
+}
+
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
+{
+    self.numberOfCallsDidEndChanging++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                  didEndChanging:(NSArray<MRTFetchedResultsControllerChange *> *)changes
+{
+    self.numberOfCallsDidEndChangingWithChanges++;
+}
+
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                  didEndChanging:(NSArray<MRTFetchedResultsControllerChange *> *)changes
+              progressiveChanges:(NSArray<MRTFetchedResultsControllerChange *> *)progressiveChanges
+{
+    self.numberOfCallsDidEndChangingWithProgressiveChanges++;
+}
+
+@end

--- a/MRTFetchedResultsControllerTests/MRTFetchedResultsControllerProgressiveChangesTests.m
+++ b/MRTFetchedResultsControllerTests/MRTFetchedResultsControllerProgressiveChangesTests.m
@@ -1135,41 +1135,37 @@
 
 #pragma mark - MRTFetchedResultsControllerDelegate
 
-- (void)controllerWillChangeContent:(MRTFetchedResultsController *)controller
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
 {
 }
 
-- (void)controllerDidChangeContent:(MRTFetchedResultsController *)controller
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
 {
     [self.didChangeContentExpectation fulfill];
 }
 
 
-- (void)controller:(MRTFetchedResultsController *)controller
-   didChangeObject:(id)anObject
-           atIndex:(NSUInteger)index
-  progressiveIndex:(NSUInteger) progressiveIndex
-     forChangeType:(MRTFetchedResultsChangeType)changeType
-forProgressiveChangeType:(MRTFetchedResultsChangeType)progressiveChangeType
-          newIndex:(NSUInteger)newIndex
-newProgressiveIndex:(NSUInteger) newProgressiveIndex;
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+               progressiveChange:(MRTFetchedResultsControllerChange *)progressiveChange
+
 {
-    switch (progressiveChangeType) {
+    switch (progressiveChange.type) {
         case MRTFetchedResultsChangeDelete:
-            NSLog(@"deleted %@ at %lu", [anObject text], progressiveIndex);
-            [self.targetArray removeObjectAtIndex:progressiveIndex];
+            NSLog(@"deleted %@ at %lu", [(Note *)progressiveChange.object text], progressiveChange.index);
+            [self.targetArray removeObjectAtIndex:progressiveChange.index];
             break;
         case MRTFetchedResultsChangeInsert:
-            NSLog(@"inserted %@ at %lu", [anObject text], newProgressiveIndex);
-            [self.targetArray insertObject:anObject atIndex:newProgressiveIndex];
+            NSLog(@"inserted %@ at %lu", [(Note *)progressiveChange.object text], progressiveChange.newIndex);
+            [self.targetArray insertObject:progressiveChange.object atIndex:progressiveChange.newIndex];
             break;
         case MRTFetchedResultsChangeUpdate:
-            NSLog(@"update %@ at %lu", [anObject text], progressiveIndex);
+            NSLog(@"update %@ at %lu", [(Note *)progressiveChange.object text], progressiveChange.index);
             break;
         case MRTFetchedResultsChangeMove:
-            NSLog(@"move %@ from %lu in %lu", [anObject text], (unsigned long)progressiveIndex, (unsigned long)newProgressiveIndex);
-            [self.targetArray removeObjectAtIndex:progressiveIndex];
-            [self.targetArray insertObject:anObject atIndex:newProgressiveIndex];
+            NSLog(@"move %@ from %lu in %lu", [(Note *)progressiveChange.object text], (unsigned long)progressiveChange.index, (unsigned long)progressiveChange.newIndex);
+            [self.targetArray removeObjectAtIndex:progressiveChange.index];
+            [self.targetArray insertObject:progressiveChange.object atIndex:progressiveChange.newIndex];
             NSLog(@"target %@", self.targetArray);
             break;
         default:

--- a/MRTFetchedResultsControllerTests/MRTTestMoveHelper.m
+++ b/MRTFetchedResultsControllerTests/MRTTestMoveHelper.m
@@ -92,11 +92,11 @@
 
 #pragma mark - MRTFetchedResultsControllerDelegate
 
-- (void)controllerWillChangeContent:(MRTFetchedResultsController *)controller
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
 {
 }
 
-- (void)controllerDidChangeContent:(MRTFetchedResultsController *)controller
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
 {
     [self.didChangeContentExpectation fulfill];
 }

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
-## MRTFetchedResultsController
-
-`MRTFetchedResultsController` provideds automatic Core Data change tracking and it's a port of `NSFetchedResultsController` for OS X (it works on iOS too). 
+## MRTFetchedResultsController - v2
+MRTFetchedResultsController provides automatic Core Data change tracking and it's a port of `NSFetchedResultsController` for OS X (it works on iOS too).
 
 ### Installation
-`MRTFetchedResultsController` is a single class with no dependencies, just download and drag the `MRTFetchedResultsController.{h,m}` files in your Xcode project. All the classes require ARC; if your project is not ARC you will have to compile them with the `-fobjc-arc` flag.
+MRTFetchedResultsController is a single class with no dependencies, just download and drag the `MRTFetchedResultsController.{h,m}` files in your Xcode project. All the classes require ARC; if your project is not ARC you will have to compile them with the `-fobjc-arc` flag.
 
 ## Table of Contents
-
 * [**MRTFetchedResultsController**](#mrtfetchedresultscontroller)
-  * [Usage](#usage)
-  * [Respond to Core Data changes](#respond-to-core-data-changes)
-  * [In-memory sorting and filtering](#in-memory-sorting-and-filtering)
-  * [fetchedObjects vs arrangedObjects](#fetchedobjects-vs-arrangedobjects)
+	* [Usage](#usage)
+	* [Respond to Core Data changes](#respond-to-core-data-changes)
+	* [In-memory sorting and filtering](#in-memory-sorting-and-filtering)
+	* [fetchedObjects vs arrangedObjects](#fetchedobjects-vs-arrangedobjects)
 * [**Unit Tests**](#unit-tests)
+* [**What’s new in v2**](#what-s-new-in-v2)
+	* [migration from v1](#migration-from-v1)
 * [**Credits**](#credits)
 * [**License**](#license)
 
 ## Usage
-
-``` obj-c
+``` objc
 // Creating a NSFetchRequest with entity/sort descriptor/predicate
 NSFetchRequest *request = [[NSFetchRequest alloc] init];
 request.entity = [NSEntityDescription entityForName:@"Notes" inManagedObjectContext:context];
@@ -43,23 +42,24 @@ else {
 ### Respond to Core Data changes
 If you want to monitor changes to objects in the associated managed object context you can assign a delegate that respond to the `MRTFetchedResultsControllerDelegate`. The controller notifies the delegate when result objects change.
 
-```obj-c
+```objc
 #pragma mark - MRTFetchedResultsControllerDelegate
 
 // Called one time for each batch of changes, BEFORE the changes are applied to the controller
-- (void)controllerWillChangeContent:(MRTFetchedResultsController *)controller
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
 {
 }
 
 // Called one time for each batch of changes, AFTER the changes are applied to the controller
-- (void)controllerDidChangeContent:(MRTFetchedResultsController *)controller
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
 {
 }
 
 // Called once per object that's being changed
-- (void)controller:(MRTFetchedResultsController *)controller didChangeObject:(id)anObject atIndex:(NSUInteger)index forChangeType:(MRTFetchedResultsChangeType)type newIndex:(NSUInteger)newIndex
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
 {
-    switch (type) {
+    switch (change.type) {
         case MRTFetchedResultsChangeDelete:
             // The object was removed from the controller
             break;
@@ -81,33 +81,134 @@ If you want to monitor changes to objects in the associated managed object conte
 ```
 
 ### In-memory sorting and filtering
-`MRTFetchedResultsController` supports in memory sorting and filtering without changing the NSFetchRequest (so you will continue to receive the correct Core Data changes notification).  
-You can sort your content by adding one or more NSSortDescriptor:
-``` obj-c
+MRTFetchedResultsController supports in memory sorting and filtering without changing the `NSFetchRequest` (so you will continue to receive the correct Core Data changes notification).  
+You can sort your content by adding one or more `NSSortDescriptor`:
+``` objc
 fetchedResultsController.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"order" ascending:YES], nil];
 NSLog(@"sorted objects %@", fetchedResultsController.arrangedObjects);
 ```
 And you can filter your objects by adding an NSPredicate:
-``` obj-c
+``` objc
 fetchedResultsController.filterPredicate = [NSPredicate predicateWithFormat:@"text LIKE %@", someText];
 NSLog(@"filtered objects %@", fetchedResultsController.arrangedObjects);
 ```
+
 ### fetchedObjects vs arrangedObjects
-Objects fetched by `MRTFetchedResultsController` can be accessed in two different way:
+Objects fetched by MRTFetchedResultsController can be accessed in two different way:
 
 1. the **fetchedObjects** property
 2. the **arrangedObjects** property
 
-For having the results of a in-memory sort or filter you must use the **arrangedObjects** property, while **fetchedObjects** will always return your original contents. If you have not set any _sortDescriptors_ or _filterPredicate_ on the fetchedResultsController, calling the **arrangedObjects** property will just return the **fetchedObjects**.
+In order to have the results of a in-memory sort or filter you must use the **arrangedObjects** property, while **fetchedObjects** will always return your original contents. If you have not set any _sortDescriptors_ or _filterPredicate_ on the fetchedResultsController, calling the **arrangedObjects** property will just return the **fetchedObjects**.
 
 ## Unit Tests
-Unit tests were performed on all the library for quality assurance. To run the tests, open the Xcode workspace, choose the 
-MRTFetchedResultsControllerTests target in the toolbar at the top, and select the menu item `Product > Test`.
+Unit tests were performed on all the library for quality assurance. To run the tests, open the Xcode workspace, choose the MRTFetchedResultsControllerTests target in the toolbar at the top, and select the menu item `Product > Test`.
 
 If you ever find a test case that is incomplete, please open an issue so we can get it fixed.
 
-## Credits
+## What’s new in v2
+The second version of MRTFetchedResultsController was mainly created to take advantage of the  `-performBatchUpdates:completion:` method of `UITableView`, having the array of changes in the callbacks at the end of the changes.
+This is what has changed:
+* the changes are returned via instances of the `MRTFetchedResultsControllerChange` class, making the signatures easier to read
+* `fetchedResultsController:didEndChanging:` and `fetchedResultsController:didEndChanging:progressiveChanges:` callbacks of the `MRTFetchedResultsControllerDelegate`provide an array of `MRTFetchedResultsControllerChange`s that can be used in the `-performBatchUpdates:completion:` of the `UITableView`
 
+### Migration from v1
+The second version of MRTFetchedResultsController has changed many signatures of the `MRTFetchedResultsControllerDelegate` callbacks. In order to update your previous code to work with MRTFetchedResultsController v2 please make the following substitutions.
+
+#### Replace 
+``` objc
+- (void)controllerWillChangeContent:(MRTFetchedResultsController *)controller
+{
+    // previous code
+}
+```
+#### With
+``` objc
+- (void)fetchedResultsControllerWillBeginChanging:(MRTFetchedResultsController *)controller
+{
+    // previous code
+}
+```
+
+---
+
+#### Replace 
+``` objc
+- (void)controllerDidChangeContent:(MRTFetchedResultsController *)controller
+{
+    // previous code
+}
+```
+#### With
+``` objc
+- (void)fetchedResultsControllerDidEndChanging:(MRTFetchedResultsController *)controller
+{
+    // previous code
+}
+```
+
+---
+
+#### Replace 
+``` objc
+- (void)controller:(MRTFetchedResultsController *)controller
+   didChangeObject:(id)anObject
+           atIndex:(NSUInteger)index
+     forChangeType:(MRTFetchedResultsChangeType)type
+          newIndex:(NSUInteger)newIndex
+{
+    // previous code
+}
+```
+#### With
+``` objc
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+{
+    id anObject = change.object;
+    MRTFetchedResultsChangeType type = change.type;
+    NSUInteger index = change.index;
+    NSUInteger newIndex = change.newIndex;
+
+    // previous code
+}
+```
+
+---
+
+#### Replace
+``` objc
+- (void)controller:(MRTFetchedResultsController *)controller
+   didChangeObject:(id)anObject
+           atIndex:(NSUInteger)index
+  progressiveIndex:(NSUInteger) progressiveIndex
+     forChangeType:(MRTFetchedResultsChangeType)changeType
+forProgressiveChangeType:(MRTFetchedResultsChangeType)progressiveChangeType
+          newIndex:(NSUInteger)newIndex
+newProgressiveIndex:(NSUInteger) newProgressiveIndex
+{
+    // previous code
+}
+```
+#### With
+``` objc
+- (void)fetchedResultsController:(MRTFetchedResultsController *)controller
+                       didChange:(MRTFetchedResultsControllerChange *)change
+               progressiveChange:(MRTFetchedResultsControllerChange *)progressiveChange
+{
+    id anObject = change.object;
+    MRTFetchedResultsChangeType changeType = change.type;
+    NSUInteger index = change.index;
+    NSUInteger newIndex = change.newIndex;
+    MRTFetchedResultsChangeType progressiveChangeType = progressiveChange.type;
+    NSUInteger progressiveIndex = progressiveChange.index;
+    NSUInteger newProgressiveIndex = progressiveChange.newIndex;
+
+    // previous code
+}
+```
+
+## Credits
 Thanks to [Indragie Karunaratne](http://indragie.com/) for his initial work on [SNRFetchedResultsController](https://github.com/indragiek/SNRFetchedResultsController). It laid the foundation for MRTFetchedResultsController.
 
 ## License


### PR DESCRIPTION
The second version of MRTFetchedResultsController was mainly created to take advantage of the `-performBatchUpdates:completion:` method of `UITableView`, having the array of changes in the callbacks at the end of the changes.

Also it changes the signatures of the callbacks of the `MRTFetchedResultsControllerDelegate` to make the 3 main types of callbacks (willChange, didChange, didEndChanging) recognisable, because the didChange is available in 2 versions as before, but the didEndChanging is now available in 3 versions:

1. no changes as before
2. with the list of changes of the current batch of changes
3. with the list of changes and of the progressiveChanges of the current batch of changes

Instructions for the migrations from v1 are provided in the README file